### PR TITLE
Add headers to response

### DIFF
--- a/example.py
+++ b/example.py
@@ -44,6 +44,7 @@ class SiteResource(Resource):
         return sites
 
     def show(self, iden):
+        self.set_header('Access-Control-Allow-Origin', '*')
         try:
             return sites[int(iden)]
         except IndexError:

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -5,6 +5,8 @@ class BaseResourceWrapper(object):
     '''
     BaseResourceWrapper is added to have common interface between frameworks.
     '''
+    request_wrapper_class = None
+
     def __init__(self, resource_class):
         '''
         :param resource_class: :class: `restea.resource.Resource` -- resource
@@ -35,6 +37,41 @@ class BaseResourceWrapper(object):
         used to make composite identifier
         '''
         raise NotImplementedError
+
+    def prepare_response(self, content, status_code, content_type):
+        '''
+        Prepares response for the given arguments.
+
+        :param content: string -- response content
+        :param status_code: string -- response status code
+        :param content_type: string -- response content type
+        '''
+        raise NotImplementedError
+
+    def get_original_request(*args, **kwargs):
+        '''
+        Returns the original request object.
+
+        This method receives all arguments that the `wrap_request` method
+        receives and return the first argument as is commonly received.
+        '''
+        return args[0]
+
+    def wrap_request(self, *args, **kwargs):
+        '''
+        Prepares data and pass control to `restea.Resource` object
+        :returns: Response object for corresponding framework
+        '''
+        data_format, kwargs = self._get_format_name(kwargs)
+        formatter = formats.get_formatter(data_format)
+        original_request = self.get_original_request(*args, **kwargs)
+
+        resource = self._resource_class(
+            self.request_wrapper_class(original_request), formatter
+        )
+        response = resource.dispatch(*args, **kwargs)
+
+        return self.prepare_response(*response)
 
 
 class BaseRequestWrapper(object):

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -45,6 +45,7 @@ class BaseResourceWrapper(object):
         :param content: string -- response content
         :param status_code: string -- response status code
         :param content_type: string -- response content type
+        :param headers: string -- response headers
         '''
         raise NotImplementedError
 

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -9,7 +9,7 @@ class BaseResourceWrapper(object):
 
     def __init__(self, resource_class):
         '''
-        :param resource_class: :class: `restea.resource.Resource` -- resource
+        :param resource_class: :class:`restea.resource.Resource` -- resource
         object implementing methods to create/edit/delete data
         '''
         self._resource_class = resource_class
@@ -65,6 +65,13 @@ class BaseResourceWrapper(object):
         data_format, kwargs = self._get_format_name(kwargs)
         formatter = formats.get_formatter(data_format)
         original_request = self.get_original_request(*args, **kwargs)
+
+        if not self.request_wrapper_class:
+            raise RuntimeError(
+                '{} must have a request_wrapper_class attribute configured.'.format(
+                    self.__class__.__name__
+                )
+            )
 
         resource = self._resource_class(
             self.request_wrapper_class(original_request), formatter

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -38,7 +38,7 @@ class BaseResourceWrapper(object):
         '''
         raise NotImplementedError
 
-    def prepare_response(self, content, status_code, content_type):
+    def prepare_response(self, content, status_code, content_type, headers):
         '''
         Prepares response for the given arguments.
 
@@ -75,9 +75,9 @@ class BaseResourceWrapper(object):
         resource = self._resource_class(
             self.request_wrapper_class(original_request), formatter
         )
-        response = resource.dispatch(*args, **kwargs)
+        response_tuple = resource.dispatch(*args, **kwargs)
 
-        return self.prepare_response(*response)
+        return self.prepare_response(*response_tuple)
 
 
 class BaseRequestWrapper(object):

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -47,7 +47,6 @@ class BaseRequestWrapper(object):
         :param original_request: -- request object from the given framework
         '''
         self._original_request = original_request
-        self._response_headers = defaultdict(list)
 
     @property
     def data(self):
@@ -84,32 +83,3 @@ class BaseRequestWrapper(object):
         :returns: string -- value from GET or None if anything is found
         '''
         raise NotImplementedError
-
-    def set_header(self, name, value):
-        '''
-        Sets the given response header name and value.
-
-        :param name: string -- header name
-        :param value: string -- header value
-        '''
-        self._response_headers[name] = [value]
-
-    def add_header(self, name, value):
-        '''
-        Sets the given response header name and value.
-
-        Unlike `set_header`, `add_header` may be called multiple times
-        to return multiple values for the same header.
-
-        :param name: string -- header name
-        :param value: string -- header value
-        '''
-        self._response_headers[name].add(value)
-
-    def clear_header(self, name):
-        '''
-        Clears an outgoing header, removing all values.
-
-        :param name: string -- header name
-        '''
-        self._response_headers.pop(name, None)

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -68,9 +68,8 @@ class BaseResourceWrapper(object):
 
         if not self.request_wrapper_class:
             raise RuntimeError(
-                '{} must have a request_wrapper_class attribute configured.'.format(
-                    self.__class__.__name__
-                )
+                '{} must have a request_wrapper_class attribute '
+                'configured.'.format(self.__class__.__name__)
             )
 
         resource = self._resource_class(

--- a/restea/adapters/base.py
+++ b/restea/adapters/base.py
@@ -47,6 +47,7 @@ class BaseRequestWrapper(object):
         :param original_request: -- request object from the given framework
         '''
         self._original_request = original_request
+        self._response_headers = defaultdict(list)
 
     @property
     def data(self):
@@ -83,3 +84,32 @@ class BaseRequestWrapper(object):
         :returns: string -- value from GET or None if anything is found
         '''
         raise NotImplementedError
+
+    def set_header(self, name, value):
+        '''
+        Sets the given response header name and value.
+
+        :param name: string -- header name
+        :param value: string -- header value
+        '''
+        self._response_headers[name] = [value]
+
+    def add_header(self, name, value):
+        '''
+        Sets the given response header name and value.
+
+        Unlike `set_header`, `add_header` may be called multiple times
+        to return multiple values for the same header.
+
+        :param name: string -- header name
+        :param value: string -- header value
+        '''
+        self._response_headers[name].add(value)
+
+    def clear_header(self, name):
+        '''
+        Clears an outgoing header, removing all values.
+
+        :param name: string -- header name
+        '''
+        self._response_headers.pop(name, None)

--- a/restea/adapters/djangowrap.py
+++ b/restea/adapters/djangowrap.py
@@ -55,12 +55,15 @@ class DjangoResourceRouter(BaseResourceWrapper):
     '''
     request_wrapper_class = DjangoRequestWrapper
 
-    def prepare_response(self, content, status_code, content_type):
-        return HttpResponse(
+    def prepare_response(self, content, status_code, content_type, headers):
+        response = HttpResponse(
             content,
             content_type=content_type,
             status=status_code
         )
+        for name, value in headers.iteritems():
+            response[name] = value
+        return response
 
     def get_routes(self, path='', iden_format='(?P<iden>\w+)'):
         '''

--- a/restea/adapters/djangowrap.py
+++ b/restea/adapters/djangowrap.py
@@ -1,4 +1,3 @@
-import restea.formats as formats
 from django.http import HttpResponse
 from django.conf.urls import patterns, url
 

--- a/restea/adapters/djangowrap.py
+++ b/restea/adapters/djangowrap.py
@@ -54,23 +54,11 @@ class DjangoResourceRouter(BaseResourceWrapper):
     Wraps over Django views, implements Django view API and creates routing in
     the Django urlrouter format
     '''
+    request_wrapper_class = DjangoRequestWrapper
 
-    def wrap_request(self, request, *args, **kwargs):
-        '''
-        Prepares data and pass control to `restea.Resource` object
-
-        :returns: :class: `django.http.HttpResponse`
-        '''
-        data_format, kwargs = self._get_format_name(kwargs)
-        formatter = formats.get_formatter(data_format)
-
-        resource = self._resource_class(
-            DjangoRequestWrapper(request), formatter
-        )
-        res, status_code, content_type = resource.dispatch(*args, **kwargs)
-
+    def prepare_response(self, content, status_code, content_type):
         return HttpResponse(
-            res,
+            content,
             content_type=content_type,
             status=status_code
         )

--- a/restea/adapters/flaskwrap.py
+++ b/restea/adapters/flaskwrap.py
@@ -1,5 +1,4 @@
 import flask
-import restea.formats as formats
 
 from restea.adapters.base import (
     BaseResourceWrapper,

--- a/restea/adapters/flaskwrap.py
+++ b/restea/adapters/flaskwrap.py
@@ -65,12 +65,15 @@ class FlaskResourceWrapper(BaseResourceWrapper):
     def get_original_request(*args, **kwargs):
         return flask.request
 
-    def prepare_response(self, content, status_code, content_type):
-        return flask.Response(
+    def prepare_response(self, content, status_code, content_type, headers):
+        response = flask.Response(
             content,
             mimetype=content_type,
             status=status_code
         )
+        for name, value in headers.iteritems():
+            response.headers[name] = value
+        return response
 
     def __adapt_path(self, path):
         '''

--- a/restea/adapters/flaskwrap.py
+++ b/restea/adapters/flaskwrap.py
@@ -53,6 +53,8 @@ class FlaskResourceWrapper(BaseResourceWrapper):
     FlaskResourceWrapper implements Flask 'view' API for the
     `restea.Resource` object, aka routing and return values in Flask format
     '''
+    request_wrapper_class = FlaskRequestWrapper
+
     @property
     def app(self):
         '''
@@ -61,22 +63,12 @@ class FlaskResourceWrapper(BaseResourceWrapper):
         '''
         return flask.current_app
 
-    def wrap_request(self, *args, **kwargs):
-        '''
-        Prepares data and pass control to `restea.Resource` object
+    def get_original_request(*args, **kwargs):
+        return flask.request
 
-        :returns: :class: `flask.Response`
-        '''
-        data_format, kwargs = self._get_format_name(kwargs)
-        formatter = formats.get_formatter(data_format)
-
-        resource = self._resource_class(
-            FlaskRequestWrapper(flask.request), formatter
-        )
-        res, status_code, content_type = resource.dispatch(*args, **kwargs)
-
+    def prepare_response(self, content, status_code, content_type):
         return flask.Response(
-            res,
+            content,
             mimetype=content_type,
             status=status_code
         )

--- a/restea/adapters/wheezywebwrap.py
+++ b/restea/adapters/wheezywebwrap.py
@@ -70,10 +70,12 @@ class WheezyResourceRouter(BaseResourceWrapper):
     '''
     request_wrapper_class = WheezyRequestWrapper
 
-    def prepare_response(self, content, status_code, content_type):
+    def prepare_response(self, content, status_code, content_type, headers):
         response = HTTPResponse(content_type=content_type)
         response.write(content)
         response.status_code = status_code
+        for name, value in headers.iteritems():
+            response.headers.append((name, value))
         return response
 
     def get_routes(self, path='', iden_format='(?P<iden>\w+)'):

--- a/restea/adapters/wheezywebwrap.py
+++ b/restea/adapters/wheezywebwrap.py
@@ -69,25 +69,11 @@ class WheezyResourceRouter(BaseResourceWrapper):
     Wraps over Wheezy web views, implements Wheezy web view API and creates
     routing in the Wheezy web urlrouter format
     '''
+    request_wrapper_class = WheezyRequestWrapper
 
-    def wrap_request(self, request, *args, **kwargs):
-        '''
-        Prepares data and pass control to `restea.Resource` object
-
-        :returns: :class: `wheezy.http.HTTPResponse`
-        '''
-        data_format, kwargs = self._get_format_name(kwargs)
-        formatter = formats.get_formatter(data_format)
-
-        resource = self._resource_class(
-            WheezyRequestWrapper(request), formatter
-        )
-        res, status_code, content_type = resource.dispatch(*args, **kwargs)
-
-        response = HTTPResponse(
-            content_type=content_type,
-        )
-        response.write(res)
+    def prepare_response(self, content, status_code, content_type):
+        response = HTTPResponse(content_type=content_type)
+        response.write(content)
         response.status_code = status_code
         return response
 

--- a/restea/adapters/wheezywebwrap.py
+++ b/restea/adapters/wheezywebwrap.py
@@ -1,4 +1,3 @@
-import restea.formats as formats
 from wheezy.http import HTTPResponse
 from wheezy.routing import url
 from wheezy.http.comp import bton

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -1,4 +1,4 @@
-erom __future__ import unicode_literals
+from __future__ import unicode_literals
 
 import collections
 

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -47,7 +47,7 @@ class Resource(object):
         '''
         return method_name not in ('list', 'create')
 
-    def _match_responce_to_fields(self, dct):
+    def _match_response_to_fields(self, dct):
         '''
         Filters output from rest method to return only fields matching
         self.fields
@@ -70,7 +70,7 @@ class Resource(object):
         :returns: filtered list, with no values out of self.fields
         :rtype: generator
         '''
-        return (self._match_responce_to_fields(item) for item in lst)
+        return (self._match_response_to_fields(item) for item in lst)
 
     def _apply_decorators(self, method):
         '''

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -245,7 +245,7 @@ class Resource(object):
             return (
                 self.process(*args, **kwargs),
                 200,
-                self.formatter.content_type
+                self.formatter.content_type,
                 self._response_headers
             )
         except errors.RestError as e:

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -269,7 +269,7 @@ class Resource(object):
 
     def clear_header(self, name):
         '''
-        Clears an outgoing header, removing all values.
+        Clears an outgoing header.
         :param name: string -- header name
         '''
         self._response_headers.pop(name, None)

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -1,6 +1,7 @@
-from __future__ import unicode_literals
+erom __future__ import unicode_literals
 
 import collections
+
 import restea.errors as errors
 import restea.formats as formats
 import restea.fields as fields
@@ -35,6 +36,7 @@ class Resource(object):
 
         self.request = request
         self.formatter = formatter
+        self._response_headers = {}
 
     def _iden_required(self, method_name):
         '''
@@ -244,6 +246,7 @@ class Resource(object):
                 self.process(*args, **kwargs),
                 200,
                 self.formatter.content_type
+                self._response_headers
             )
         except errors.RestError as e:
             err = e.info.copy()
@@ -252,5 +255,21 @@ class Resource(object):
             return (
                 self._error_formatter.serialize(err),
                 e.http_code,
-                self._error_formatter.content_type
+                self._error_formatter.content_type,
+                self._response_headers
             )
+
+    def set_header(self, name, value):
+        '''
+        Sets the given response header name and value.
+        :param name: string -- header name
+        :param value: string -- header value
+        '''
+        self._response_headers[name] = value
+
+    def clear_header(self, name):
+        '''
+        Clears an outgoing header, removing all values.
+        :param name: string -- header name
+        '''
+        self._response_headers.pop(name, None)

--- a/restea/resource.py
+++ b/restea/resource.py
@@ -36,7 +36,7 @@ class Resource(object):
 
         self.request = request
         self.formatter = formatter
-        self._response_headers = {}
+        self._response_headers = collections.OrderedDict()
 
     def _iden_required(self, method_name):
         '''

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ f = open("README.rst")
 try:
     try:
         readme_content = f.read()
-    except:
+    except Exception:
         readme_content = ""
 finally:
     f.close()

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -99,7 +99,7 @@ def test_iden_required_negative():
     assert resource._iden_required('list') is False
 
 
-def test_match_responce_to_fields():
+def test_match_response_to_fields():
     resource, _, _ = create_resource_helper()
     resource.fields = mock.Mock(spec=fields.FieldSet)
     resource.fields.field_names = ['name1', 'name2', 'name3']
@@ -107,10 +107,10 @@ def test_match_responce_to_fields():
     data = {'name1': 1, 'name2': 2, 'name3': 3, 'name4': 4}
     expected_data = {'name1': 1, 'name2': 2, 'name3': 3}
 
-    assert resource._match_responce_to_fields(data) == expected_data
+    assert resource._match_response_to_fields(data) == expected_data
 
 
-def test_match_responce_list_to_fields():
+def test_match_response_list_to_fields():
     resource, _, _ = create_resource_helper()
     resource.fields = mock.Mock(spec=fields.FieldSet)
     resource.fields.field_names = ['name1', 'name2', 'name3']


### PR DESCRIPTION
Hey @bodbdigr,

Here is a changeset to provide the ability to add headers to responses using almost the [same approach than Tornado uses](https://github.com/tornadoweb/tornado/blob/8906b3a/tornado/web.py#L331-L357). For now, developers will be able to use only one value per header name, but in a near future, I hope to send a new pull request supporting multiple values.

You can see a refactor on `wrap_request` method, this is going to DRY a logic to receive arguments to delegate and convert a request object into a response. :) 

Please be so kind to review and merge my changes. Thanks in advance.